### PR TITLE
docs: Add critical severity threshold option

### DIFF
--- a/help/README.md
+++ b/help/README.md
@@ -24,11 +24,11 @@ See other documents and help files for hints on how to format arguments. Keep fo
 ### CLI options
 
 ```md
-- `--severity-threshold`=low|medium|high:
+- `--severity-threshold`=low|medium|high|critical:
   Only report vulnerabilities of provided level or higher.
 ```
 
-CLI flag should be in backticks. Options (filenames, org names…) should use Keyword extension (see below) and literal options (true|false, low|medium|high…) should be typed as above.
+CLI flag should be in backticks. Options (filenames, org names…) should use Keyword extension (see below) and literal options (true|false, low|medium|high|critical…) should be typed as above.
 
 ### Keyword extension
 

--- a/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
+++ b/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
@@ -86,7 +86,7 @@ For advanced usage, we offer language and context specific flags, listed further
   Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
   This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
 
-- `--severity-threshold`=low|medium|high:
+- `--severity-threshold`=low|medium|high|critical:
   Only report vulnerabilities of provided level or higher.
 
 - `--fail-on`=all|upgradable|patchable:

--- a/help/commands-docs/container.md
+++ b/help/commands-docs/container.md
@@ -53,7 +53,7 @@ Find vulnerabilities in your container images.
 - `--policy-path`=<PATH_TO_POLICY_FILE>:
   Manually pass a path to a snyk policy file.
 
-- `--severity-threshold`=low|medium|high:
+- `--severity-threshold`=low|medium|high|critical:
   Only report vulnerabilities of provided level or higher.
   
 - `--username`=<CONTAINER_REGISTRY_USERNAME>:


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Documents `critical` as an option for `--severity-threshold` (for products using CVSS)
